### PR TITLE
add extra instructions for developing on windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ yarn test
 
 The options for running tests can be selected from the cli or be passed to `yarn test` with specific parameters. Available modes include `--watch`, `--coverage`, and `--runInBand`, which will respectively run tests in watch mode, output code coverage, and run selected test suites serially in the current process.
 
-You can use the `--update` flag to update snapshots or screenshots as needed.
+You can use the `--update` flag (or `jest -u`) to update snapshots or screenshots as needed.
+ 
+> NOTE: on Windows, remember to make sure git config `core.autocrlf` is set to false, in order to not override EOL in snapshots ( `git config --global core.autocrlf false` to set it globally). It is also recommended to run tests from WSL2 to avoid errors with unix-style paths.
 
 You can also pick suites from CLI. Suites available are listed below.
 


### PR DESCRIPTION
Issue:

## What I did

Updated CONTRIBUTING.md with more information regarding developing on Windows

## How to test

- Is this testable with Jest or Chromatic screenshots? N/A
- Does this need a new example in the kitchen sink apps?  N/A
- Does this need an update to the documentation? This is an update to the documentation

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
